### PR TITLE
[TRIS-297] Configurable SSL Connection

### DIFF
--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -64,7 +64,6 @@ jobs:
 
   integration:
     runs-on: ubuntu-latest
-    needs: integration1
 
     services:
       db_test: # This will be the hostname

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -72,6 +72,8 @@ jobs:
           mkdir certs
           openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
           openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
+          ls
+          ls /certs
           cat /certs/root.crt >> /certs/server.crt
           echo "SSL Certs Generated"
 
@@ -98,6 +100,7 @@ jobs:
 
   integration2:
     runs-on: ubuntu-latest
+    needs: integration1
 
     strategy:
       matrix:

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -132,4 +132,6 @@ jobs:
       - name: Add required test DB alias name for localhost
         run: echo "127.0.0.1 db_test" | sudo tee -a /etc/hosts
       - name: Run Tox
-        run: tox -v -e integration
+        run: |
+          ls
+          tox -v -e integration

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -72,9 +72,9 @@ jobs:
           mkdir certs
           ls
           ls certs
-          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
-          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
-          cat /certs/root.crt >> /certs/server.crt
+          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out certs/server.crt -keyout certs/server.key -subj "/CN=localhost"
+          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out certs/root.crt -keyout certs/root.key -subj "/CN=localhost"
+          cat certs/root.crt >> certs/server.crt
           echo "SSL Certs Generated"
 
     services:
@@ -86,9 +86,9 @@ jobs:
           POSTGRES_DB: test
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_SSL: on
-          POSTGRES_SSL_CERT_FILE: /certs/server.crt
-          POSTGRES_SSL_KEY_FILE: /certs/server.key
-          POSTGRES_SSL_CA_FILE: /certs/root.crt
+          POSTGRES_SSL_CERT_FILE: certs/server.crt
+          POSTGRES_SSL_KEY_FILE: certs/server.key
+          POSTGRES_SSL_CA_FILE: certs/root.crt
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -72,6 +72,7 @@ jobs:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
           POSTGRES_DB: test
+          PGDATA: /certs
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -92,6 +93,7 @@ jobs:
       MF_METADATA_DB_PSWD: test
       MF_METADATA_DB_NAME: test
       MF_METADATA_DB_SSL_MODE: require
+      MF_METADATA_DB_SSL_ROOT_CERT_PATH: /certs/server.crt
 
     steps:
       - uses: zendesk/checkout@v2

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -65,6 +65,14 @@ jobs:
   integration:
     runs-on: ubuntu-latest
 
+    steps:
+      - uses: zendesk/checkout@v2
+      - name: Generate SSL certificates
+        run: |
+          openssl req -new -x509 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
+          openssl req -new -x509 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
+          cat /certs/root.crt >> /certs/server.crt
+
     services:
       db_test: # This will be the hostname
         image: postgres:11
@@ -74,9 +82,9 @@ jobs:
           POSTGRES_DB: test
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_SSL: on
-          POSTGRES_SSL_CERT_FILE: /var/lib/postgresql/server.crt
-          POSTGRES_SSL_KEY_FILE: /var/lib/postgresql/server.key
-          POSTGRES_SSL_CA_FILE: /var/lib/postgresql/root.crt
+          POSTGRES_SSL_CERT_FILE: /certs/server.crt
+          POSTGRES_SSL_KEY_FILE: /certs/server.key
+          POSTGRES_SSL_CA_FILE: /certs/root.crt
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -101,12 +109,6 @@ jobs:
       MF_METADATA_DB_SSL_MODE: require
 
     steps:
-      - uses: zendesk/checkout@v2
-      - name: Generate SSL certificates
-        run: |
-          openssl req -new -x509 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
-          openssl req -new -x509 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
-          cat /certs/root.crt >> /certs/server.crt
       - uses: zendesk/setup-go@v2
         with:
           go-version: ${{ matrix.golang-version }}

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -71,8 +71,9 @@ jobs:
         run: |
           mkdir certs
           openssl req -newkey -x509 rsa:4096 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
-          openssl req -newkey -x509 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
+          openssl req -newkey -x509 rsa:4096 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
           cat /certs/root.crt >> /certs/server.crt
+          echo "SSL Certs Generated"
 
     services:
       db_test: # This will be the hostname

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -1,0 +1,126 @@
+name: Test-SSL
+on: push
+
+jobs:
+  codestyle:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python ${{ matrix.python-version }} dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pycodestyle
+      - name: Run Python PEP8 code style checks
+        run: pycodestyle
+
+  pylint:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python ${{ matrix.python-version }} dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox pylint
+      - name: Run Tox (pylint)
+        run: tox -e pylint
+
+  unit:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python ${{ matrix.python-version }} dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+      - name: Run Tox
+        run: tox -e unit
+
+  integration:
+    runs-on: ubuntu-latest
+
+    services:
+      db_test: # This will be the hostname
+        image: postgres:11
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_SSL: on
+          POSTGRES_SSL_CERT_FILE: /var/lib/postgresql/server.crt
+          POSTGRES_SSL_KEY_FILE: /var/lib/postgresql/server.key
+          POSTGRES_SSL_CA_FILE: : /var/lib/postgresql/root.crt
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+        volumes:
+          - ./certs:/certs
+
+    strategy:
+      matrix:
+        python-version: [3.7]
+        golang-version: ["^1.14.5"]
+
+    env:
+      MF_METADATA_DB_HOST: db_test
+      MF_METADATA_DB_PORT: 5432
+      MF_METADATA_DB_USER: test
+      MF_METADATA_DB_PSWD: test
+      MF_METADATA_DB_NAME: test
+      MF_METADATA_DB_SSL_MODE: require
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate SSL certificates
+        run: |
+          openssl req -new -x509 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
+          openssl req -new -x509 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
+          cat /certs/root.crt >> /certs/server.crt
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.golang-version }}
+      - name: Install goose migration tool
+        run: go install github.com/pressly/goose/v3/cmd/goose@v3.5.3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Python ${{ matrix.python-version }} dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+      - name: Add required test DB alias name for localhost
+        run: echo "127.0.0.1 db_test" | sudo tee -a /etc/hosts
+      - name: Run Tox
+        run: tox -v -e integration

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -80,16 +80,12 @@ jobs:
 
     services:
       db_test: # This will be the hostname
-        image: postgres:11
+        image: ghcr.io/infrastructure-as-code/postgres:11
         env:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
           POSTGRES_DB: test
           POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_SSL: on
-          POSTGRES_SSL_CERT_FILE: ${{ github.workspace }}/server.crt
-          POSTGRES_SSL_KEY_FILE: ${{ github.workspace }}/server.key
-          POSTGRES_SSL_CA_FILE: ${{ github.workspace }}/root.crt
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -62,19 +62,7 @@ jobs:
       - name: Run Tox
         run: tox -e unit
 
-  integration1:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: zendesk/checkout@v2
-      - name: Generate SSL certificates
-        run: |
-          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out ${{ github.workspace }}/server.crt -keyout ${{ github.workspace }}/server.key -subj "/CN=localhost"
-          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out ${{ github.workspace }}/root.crt -keyout ${{ github.workspace }}/root.key -subj "/CN=localhost"
-          cat ${{ github.workspace }}/root.crt >> ${{ github.workspace }}/server.crt
-          echo "SSL Certs Generated"
-
-  integration2:
+  integration:
     runs-on: ubuntu-latest
     needs: integration1
 

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Generate SSL certificates
         run: |
           mkdir certs
-          openssl req -newkey -x509 -rsa:4096 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
+          openssl req -newkey -x509 rsa:4096 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
           openssl req -newkey -x509 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
           cat /certs/root.crt >> /certs/server.crt
 

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -70,10 +70,10 @@ jobs:
       - name: Generate SSL certificates
         run: |
           mkdir certs
-          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
-          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
           ls
           ls /certs
+          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
+          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
           cat /certs/root.crt >> /certs/server.crt
           echo "SSL Certs Generated"
 

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -116,6 +116,7 @@ jobs:
       MF_METADATA_DB_SSL_MODE: require
 
     steps:
+      - uses: zendesk/checkout@v2
       - uses: zendesk/setup-go@v2
         with:
           go-version: ${{ matrix.golang-version }}

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: zendesk/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: zendesk/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Python ${{ matrix.python-version }} dependencies
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: zendesk/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: zendesk/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Python ${{ matrix.python-version }} dependencies

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           mkdir certs
           ls
-          ls /certs
+          ls certs
           openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
           openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
           cat /certs/root.crt >> /certs/server.crt

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Generate SSL certificates
         run: |
           mkdir certs
-          openssl req -new -x509 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
-          openssl req -new -x509 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
+          openssl req -newkey -x509 -rsa:4096 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
+          openssl req -newkey -x509 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
           cat /certs/root.crt >> /certs/server.crt
 
     services:

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -10,7 +10,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: zendesk/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -30,7 +30,7 @@ jobs:
         python-version: [3.7]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: zendesk/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -50,9 +50,9 @@ jobs:
         python-version: [3.7]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: zendesk/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: zendesk/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Python ${{ matrix.python-version }} dependencies
@@ -101,19 +101,19 @@ jobs:
       MF_METADATA_DB_SSL_MODE: require
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: zendesk/checkout@v2
       - name: Generate SSL certificates
         run: |
           openssl req -new -x509 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
           openssl req -new -x509 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
           cat /certs/root.crt >> /certs/server.crt
-      - uses: actions/setup-go@v2
+      - uses: zendesk/setup-go@v2
         with:
           go-version: ${{ matrix.golang-version }}
       - name: Install goose migration tool
         run: go install github.com/pressly/goose/v3/cmd/goose@v3.5.3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: zendesk/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Python ${{ matrix.python-version }} dependencies

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -76,7 +76,7 @@ jobs:
           POSTGRES_SSL: on
           POSTGRES_SSL_CERT_FILE: /var/lib/postgresql/server.crt
           POSTGRES_SSL_KEY_FILE: /var/lib/postgresql/server.key
-          POSTGRES_SSL_CA_FILE: : /var/lib/postgresql/root.crt
+          POSTGRES_SSL_CA_FILE: /var/lib/postgresql/root.crt
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -92,12 +92,10 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-        volumes:
-          - ./certs:/certs
 
   integration2:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         python-version: [3.7]

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -92,6 +92,10 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+        volumes:
+          - name: certs-volume
+            path: /certs
+
 
   integration2:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Generate SSL certificates
         run: |
           mkdir certs
-          openssl req -newkey -x509 rsa:4096 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
-          openssl req -newkey -x509 rsa:4096 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
+          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
+          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
           cat /certs/root.crt >> /certs/server.crt
           echo "SSL Certs Generated"
 

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -69,13 +69,14 @@ jobs:
       - uses: zendesk/checkout@v2
       - name: Generate SSL certificates
         run: |
-          mkdir certs
-          ls
-          ls certs
-          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out certs/server.crt -keyout certs/server.key -subj "/CN=localhost"
-          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out certs/root.crt -keyout certs/root.key -subj "/CN=localhost"
-          cat certs/root.crt >> certs/server.crt
+          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out ${{ github.workspace }}/server.crt -keyout ${{ github.workspace }}/server.key -subj "/CN=localhost"
+          openssl req -x509 -newkey rsa:4096 -days 365 -nodes -out ${{ github.workspace }}/root.crt -keyout ${{ github.workspace }}/root.key -subj "/CN=localhost"
+          cat ${{ github.workspace }}/root.crt >> ${{ github.workspace }}/server.crt
           echo "SSL Certs Generated"
+
+  integration2:
+    runs-on: ubuntu-latest
+    needs: integration1
 
     services:
       db_test: # This will be the hostname
@@ -86,9 +87,9 @@ jobs:
           POSTGRES_DB: test
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_SSL: on
-          POSTGRES_SSL_CERT_FILE: certs/server.crt
-          POSTGRES_SSL_KEY_FILE: certs/server.key
-          POSTGRES_SSL_CA_FILE: certs/root.crt
+          POSTGRES_SSL_CERT_FILE: ${{ github.workspace }}/server.crt
+          POSTGRES_SSL_KEY_FILE: ${{ github.workspace }}/server.key
+          POSTGRES_SSL_CA_FILE: ${{ github.workspace }}/root.crt
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -96,11 +97,6 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-
-
-  integration2:
-    runs-on: ubuntu-latest
-    needs: integration1
 
     strategy:
       matrix:

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run Tox
         run: tox -e unit
 
-  integration:
+  integration1:
     runs-on: ubuntu-latest
 
     steps:
@@ -95,6 +95,9 @@ jobs:
         volumes:
           - ./certs:/certs
 
+  integration2:
+    runs-on: ubuntu-latest
+    
     strategy:
       matrix:
         python-version: [3.7]

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -72,7 +72,7 @@ jobs:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
           POSTGRES_DB: test
-          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_HOST_AUTH_METHOD: password
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -72,7 +72,6 @@ jobs:
           POSTGRES_USER: test
           POSTGRES_PASSWORD: test
           POSTGRES_DB: test
-          POSTGRES_HOST_AUTH_METHOD: password
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -93,8 +93,7 @@ jobs:
         ports:
           - 5432:5432
         volumes:
-          - name: certs-volume
-            path: /certs
+          - /certs
 
 
   integration2:

--- a/.github/workflows/test-ssl.yml
+++ b/.github/workflows/test-ssl.yml
@@ -69,6 +69,7 @@ jobs:
       - uses: zendesk/checkout@v2
       - name: Generate SSL certificates
         run: |
+          mkdir certs
           openssl req -new -x509 -days 365 -nodes -out /certs/server.crt -keyout /certs/server.key -subj "/CN=localhost"
           openssl req -new -x509 -days 365 -nodes -out /certs/root.crt -keyout /certs/root.key -subj "/CN=localhost"
           cat /certs/root.crt >> /certs/server.crt
@@ -92,8 +93,6 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-        volumes:
-          - /certs
 
 
   integration2:

--- a/run_goose.py
+++ b/run_goose.py
@@ -51,13 +51,28 @@ def main():
     parser.add_argument("--wait", type=int, default=30, help="Wait for connection for X seconds")
     args = parser.parse_args()
 
-    db_connection_string = "postgresql://{}:{}@{}:{}/{}?sslmode=require".format(
+    
+
+    db_connection_string = "postgresql://{}:{}@{}:{}/{}".format(
         quote(os.environ["MF_METADATA_DB_USER"]),
         quote(os.environ["MF_METADATA_DB_PSWD"]),
         os.environ["MF_METADATA_DB_HOST"],
         os.environ["MF_METADATA_DB_PORT"],
         os.environ["MF_METADATA_DB_NAME"],
     )
+
+    _ssl_mode = os.environ["MF_METADATA_DB_SSL_MODE"]
+    _ssl_cert_path = os.environ["MF_METADATA_DB_SSL_CERT_PATH"]
+    _ssl_key_path = os.environ["MF_METADATA_DB_SSL_KEY_PATH"]
+    _ssl_root_cert_path = os.environ["MF_METADATA_DB_SSL_ROOT_CERT"]
+    ssl_query = ""
+    if(_ssl_mode == "require"):
+        ssl_query = "sslmode=require"
+        if _ssl_cert_path is not None: ssl_query = ssl_query + "&sslcert="+_ssl_cert_path
+        if _ssl_key_path is not None: ssl_query = ssl_query + "&sslkey="+_ssl_key_path
+        if _ssl_root_cert_path is not None: ssl_query = ssl_query + "&sslrootcert="+_ssl_root_cert_path
+    else: ssl_query = "sslmode=disable"
+    db_connection_string = db_connection_string + "?" + ssl_query
 
     if args.wait:
         wait_for_postgres(db_connection_string, timeout_seconds=args.wait)

--- a/run_goose.py
+++ b/run_goose.py
@@ -51,7 +51,7 @@ def main():
     parser.add_argument("--wait", type=int, default=30, help="Wait for connection for X seconds")
     args = parser.parse_args()
 
-    db_connection_string = "postgresql://{}:{}@{}:{}/{}?sslmode=disable".format(
+    db_connection_string = "postgresql://{}:{}@{}:{}/{}?sslmode=require".format(
         quote(os.environ["MF_METADATA_DB_USER"]),
         quote(os.environ["MF_METADATA_DB_PSWD"]),
         os.environ["MF_METADATA_DB_HOST"],

--- a/run_goose.py
+++ b/run_goose.py
@@ -60,8 +60,8 @@ def main():
     ssl_key_path = os.environ["MF_METADATA_DB_SSL_KEY_PATH"]
     ssl_root_cert_path = os.environ["MF_METADATA_DB_SSL_ROOT_CERT"]
 
-    if (ssl_mode == 'require'):
-        ssl_query = f'sslmode=require'
+    if (ssl_mode in ['allow', 'prefer', 'require', 'verify-ca', 'verify-full']):
+        ssl_query = ssl_mode
         if ssl_cert_path is not None:
             ssl_query = f'{ssl_query}&sslcert={ssl_cert_path}'
         if ssl_key_path is not None:

--- a/run_goose.py
+++ b/run_goose.py
@@ -54,7 +54,7 @@ def main():
     db_connection_string = f'postgresql://{quote(os.environ["MF_METADATA_DB_USER"])}:'\
         f'{quote(os.environ["MF_METADATA_DB_PSWD"])}@{os.environ["MF_METADATA_DB_HOST"]}:'\
         f'{os.environ["MF_METADATA_DB_PORT"]}/{os.environ["MF_METADATA_DB_NAME"]}'
-    
+
     ssl_mode = os.environ["MF_METADATA_DB_SSL_MODE"]
     ssl_cert_path = os.environ["MF_METADATA_DB_SSL_CERT_PATH"]
     ssl_key_path = os.environ["MF_METADATA_DB_SSL_KEY_PATH"]
@@ -70,7 +70,7 @@ def main():
             ssl_query = f'{ssl_query}&sslrootcert={ssl_root_cert_path}'
     else:
         ssl_query = f'sslmode=disable'
-    
+
     db_connection_string = f'{db_connection_string}?{ssl_query}'
 
     if args.wait:

--- a/run_goose.py
+++ b/run_goose.py
@@ -64,12 +64,16 @@ def main():
     _ssl_key_path = os.environ["MF_METADATA_DB_SSL_KEY_PATH"]
     _ssl_root_cert_path = os.environ["MF_METADATA_DB_SSL_ROOT_CERT"]
     ssl_query = ""
-    if(_ssl_mode == "require"):
+    if (_ssl_mode == "require"):
         ssl_query = "sslmode=require"
-        if _ssl_cert_path is not None: ssl_query = ssl_query + "&sslcert=" + _ssl_cert_path
-        if _ssl_key_path is not None: ssl_query = ssl_query + "&sslkey=" + _ssl_key_path
-        if _ssl_root_cert_path is not None: ssl_query = ssl_query + "&sslrootcert=" + _ssl_root_cert_path
-    else: ssl_query = "sslmode=disable"
+        if _ssl_cert_path is not None:
+            ssl_query = ssl_query + "&sslcert=" + _ssl_cert_path
+        if _ssl_key_path is not None:
+            ssl_query = ssl_query + "&sslkey=" + _ssl_key_path
+        if _ssl_root_cert_path is not None:
+            ssl_query = ssl_query + "&sslrootcert=" + _ssl_root_cert_path
+    else:
+        ssl_query = "sslmode=disable"
     db_connection_string = db_connection_string + "?" + ssl_query
 
     if args.wait:

--- a/run_goose.py
+++ b/run_goose.py
@@ -51,8 +51,6 @@ def main():
     parser.add_argument("--wait", type=int, default=30, help="Wait for connection for X seconds")
     args = parser.parse_args()
 
-    
-
     db_connection_string = "postgresql://{}:{}@{}:{}/{}".format(
         quote(os.environ["MF_METADATA_DB_USER"]),
         quote(os.environ["MF_METADATA_DB_PSWD"]),
@@ -68,9 +66,9 @@ def main():
     ssl_query = ""
     if(_ssl_mode == "require"):
         ssl_query = "sslmode=require"
-        if _ssl_cert_path is not None: ssl_query = ssl_query + "&sslcert="+_ssl_cert_path
-        if _ssl_key_path is not None: ssl_query = ssl_query + "&sslkey="+_ssl_key_path
-        if _ssl_root_cert_path is not None: ssl_query = ssl_query + "&sslrootcert="+_ssl_root_cert_path
+        if _ssl_cert_path is not None: ssl_query = ssl_query + "&sslcert=" + _ssl_cert_path
+        if _ssl_key_path is not None: ssl_query = ssl_query + "&sslkey=" + _ssl_key_path
+        if _ssl_root_cert_path is not None: ssl_query = ssl_query + "&sslrootcert=" + _ssl_root_cert_path
     else: ssl_query = "sslmode=disable"
     db_connection_string = db_connection_string + "?" + ssl_query
 

--- a/run_goose.py
+++ b/run_goose.py
@@ -51,14 +51,10 @@ def main():
     parser.add_argument("--wait", type=int, default=30, help="Wait for connection for X seconds")
     args = parser.parse_args()
 
-    db_connection_string = "postgresql://{}:{}@{}:{}/{}".format(
-        quote(os.environ["MF_METADATA_DB_USER"]),
-        quote(os.environ["MF_METADATA_DB_PSWD"]),
-        os.environ["MF_METADATA_DB_HOST"],
-        os.environ["MF_METADATA_DB_PORT"],
-        os.environ["MF_METADATA_DB_NAME"],
-    )
-
+    db_connection_string = f'postgresql://{quote(os.environ["MF_METADATA_DB_USER"])}:'\
+                        f'{quote(os.environ["MF_METADATA_DB_PSWD"])}@{os.environ["MF_METADATA_DB_HOST"]}:'\
+                        f'{os.environ["MF_METADATA_DB_PORT"]}/{os.environ["MF_METADATA_DB_NAME"]}'
+    
     ssl_mode = os.environ["MF_METADATA_DB_SSL_MODE"]
     ssl_cert_path = os.environ["MF_METADATA_DB_SSL_CERT_PATH"]
     ssl_key_path = os.environ["MF_METADATA_DB_SSL_KEY_PATH"]

--- a/run_goose.py
+++ b/run_goose.py
@@ -61,7 +61,7 @@ def main():
     ssl_root_cert_path = os.environ["MF_METADATA_DB_SSL_ROOT_CERT"]
 
     if (ssl_mode in ['allow', 'prefer', 'require', 'verify-ca', 'verify-full']):
-        ssl_query = ssl_mode
+        ssl_query = f'ssl_mode={ssl_mode}'
         if ssl_cert_path is not None:
             ssl_query = f'{ssl_query}&sslcert={ssl_cert_path}'
         if ssl_key_path is not None:

--- a/run_goose.py
+++ b/run_goose.py
@@ -52,8 +52,8 @@ def main():
     args = parser.parse_args()
 
     db_connection_string = f'postgresql://{quote(os.environ["MF_METADATA_DB_USER"])}:'\
-                        f'{quote(os.environ["MF_METADATA_DB_PSWD"])}@{os.environ["MF_METADATA_DB_HOST"]}:'\
-                        f'{os.environ["MF_METADATA_DB_PORT"]}/{os.environ["MF_METADATA_DB_NAME"]}'
+        f'{quote(os.environ["MF_METADATA_DB_PSWD"])}@{os.environ["MF_METADATA_DB_HOST"]}:'\
+        f'{os.environ["MF_METADATA_DB_PORT"]}/{os.environ["MF_METADATA_DB_NAME"]}'
     
     ssl_mode = os.environ["MF_METADATA_DB_SSL_MODE"]
     ssl_cert_path = os.environ["MF_METADATA_DB_SSL_CERT_PATH"]

--- a/run_goose.py
+++ b/run_goose.py
@@ -59,22 +59,23 @@ def main():
         os.environ["MF_METADATA_DB_NAME"],
     )
 
-    _ssl_mode = os.environ["MF_METADATA_DB_SSL_MODE"]
-    _ssl_cert_path = os.environ["MF_METADATA_DB_SSL_CERT_PATH"]
-    _ssl_key_path = os.environ["MF_METADATA_DB_SSL_KEY_PATH"]
-    _ssl_root_cert_path = os.environ["MF_METADATA_DB_SSL_ROOT_CERT"]
-    ssl_query = ""
-    if (_ssl_mode == "require"):
-        ssl_query = "sslmode=require"
-        if _ssl_cert_path is not None:
-            ssl_query = ssl_query + "&sslcert=" + _ssl_cert_path
-        if _ssl_key_path is not None:
-            ssl_query = ssl_query + "&sslkey=" + _ssl_key_path
-        if _ssl_root_cert_path is not None:
-            ssl_query = ssl_query + "&sslrootcert=" + _ssl_root_cert_path
+    ssl_mode = os.environ["MF_METADATA_DB_SSL_MODE"]
+    ssl_cert_path = os.environ["MF_METADATA_DB_SSL_CERT_PATH"]
+    ssl_key_path = os.environ["MF_METADATA_DB_SSL_KEY_PATH"]
+    ssl_root_cert_path = os.environ["MF_METADATA_DB_SSL_ROOT_CERT"]
+
+    if (ssl_mode == 'require'):
+        ssl_query = f'sslmode=require'
+        if ssl_cert_path is not None:
+            ssl_query = f'{ssl_query}&sslcert={ssl_cert_path}'
+        if ssl_key_path is not None:
+            ssl_query = f'{ssl_query}&sslkey={ssl_key_path}'
+        if ssl_root_cert_path is not None:
+            ssl_query = f'{ssl_query}&sslrootcert={ssl_root_cert_path}'
     else:
-        ssl_query = "sslmode=disable"
-    db_connection_string = db_connection_string + "?" + ssl_query
+        ssl_query = f'sslmode=disable'
+    
+    db_connection_string = f'{db_connection_string}?{ssl_query}'
 
     if args.wait:
         wait_for_postgres(db_connection_string, timeout_seconds=args.wait)

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -248,7 +248,7 @@ class DBConfiguration(object):
     @property
     def connection_string_url(self):
         # postgresql://[user[:password]@][host][:port][/dbname][?param1=value1&...]
-        return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=disable'
+        return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=require'
 
     @property
     def dsn(self):

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -193,6 +193,10 @@ class DBConfiguration(object):
                  user: str = "postgres",
                  password: str = "postgres",
                  database_name: str = "postgres",
+                 ssl_mode: str = "disabled",
+                 ssl_cert_path: str = None,
+                 ssl_key_path: str = None,
+                 ssl_root_cert_path: str = None,
                  prefix="MF_METADATA_DB_",
                  pool_min: int = 1,
                  pool_max: int = 10,
@@ -209,6 +213,10 @@ class DBConfiguration(object):
         self._user = os.environ.get(prefix + "USER", user)
         self._password = os.environ.get(prefix + "PSWD", password)
         self._database_name = os.environ.get(prefix + "NAME", database_name)
+        self._ssl_mode = os.environ.get(prefix+"SSL_MODE", ssl_mode)
+        self._ssl_cert_path = os.environ.get(prefix+"SSL_CERT_PATH", ssl_cert_path)
+        self._ssl_key_path = os.environ.get(prefix+"SSL_KEY_PATH", ssl_key_path),
+        self._ssl_root_cert_path = os.environ.get(prefix+"SSL_ROOT_CERT_PATH", ssl_root_cert_path)
         conn_str_required_values = [
             self._host,
             self._port,
@@ -248,8 +256,16 @@ class DBConfiguration(object):
     @property
     def connection_string_url(self):
         # postgresql://[user[:password]@][host][:port][/dbname][?param1=value1&...]
-        return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=require'
-
+        # return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=require'
+        base_url = f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}'
+        ssl_query = ''
+        if(self._ssl_mode == 'require'):
+            ssl_query = 'sslmode=require'
+            if self._ssl_cert_path is not None: ssl_query = ssl_query + '&sslcert='+self._ssl_cert_path
+            if self._ssl_key_path is not None: ssl_query = ssl_query + '&sslkey='+self._ssl_key_path
+            if self._ssl_root_cert_path is not None: ssl_query = ssl_query + '&sslrootcert='+self._ssl_root_cert_path
+        else: ssl_query = 'sslmode=disable'
+        return base_url + '?' + ssl_query
     @property
     def dsn(self):
         if self._dsn is None:

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -258,8 +258,8 @@ class DBConfiguration(object):
         # postgresql://[user[:password]@][host][:port][/dbname][?param1=value1&...]
         # return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=require'
         base_url = f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}'
-        if (self._ssl_mode == 'require'):
-            ssl_query = f'sslmode=require'
+        if (self._ssl_mode in ['allow', 'prefer', 'require', 'verify-ca', 'verify-full']):
+            ssl_query = self._ssl_mode
             if self._ssl_cert_path is not None:
                 ssl_query = f'{ssl_query}&sslcert={self._ssl_cert_path}'
             if self._ssl_key_path is not None:

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -285,15 +285,15 @@ class DBConfiguration(object):
                 sslkey = None
                 sslrootcert = None
             kwargs = {
-                'dbname':self._database_name,
-                'user':self._user,
-                'host':self._host,
-                'port':self._port,
-                'password':self._password,
-                'sslmode':ssl_mode,
-                'sslcert':sslcert,
-                'sslkey':sslkey,
-                'sslrootcert':sslrootcert
+                'dbname': self._database_name,
+                'user': self._user,
+                'host': self._host,
+                'port': self._port,
+                'password': self._password,
+                'sslmode': ssl_mode,
+                'sslcert': sslcert,
+                'sslkey': sslkey,
+                'sslrootcert': sslrootcert
             }
             return psycopg2.extensions.make_dsn(**{k: v for k, v in kwargs.items() if v is not None})  
         else:

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -275,27 +275,27 @@ class DBConfiguration(object):
     @property
     def dsn(self):
         if self._dsn is None:
-            if (self._ssl_mode in ['allow', 'prefer', 'require', 'verify-ca', 'verify-full']):
-                return psycopg2.extensions.make_dsn(
-                    dbname=self._database_name,
-                    user=self._user,
-                    host=self._host,
-                    port=self._port,
-                    password=self._password,
-                    sslmode=self._ssl_mode,
-                    sslcert=self._ssl_cert_path,
-                    sslkey=self._ssl_key_path,
-                    sslrootcert=self._ssl_root_cert_path
-                )
-            else:
-                return psycopg2.extensions.make_dsn(
-                    dbname=self._database_name,
-                    user=self._user,
-                    host=self._host,
-                    port=self._port,
-                    password=self._password,
-                    sslmode='disable'
-                )
+            ssl_mode = self._ssl_mode
+            sslcert = self._ssl_cert_path
+            sslkey = self._ssl_key_path
+            sslrootcert = self._ssl_root_cert_path
+            if (ssl_mode not in ['allow', 'prefer', 'require', 'verify-ca', 'verify-full']):
+                ssl_mode = 'disable'
+                sslcert = None
+                sslkey = None
+                sslrootcert = None
+            kwargs = {
+                'dbname':self._database_name,
+                'user':self._user,
+                'host':self._host,
+                'port':self._port,
+                'password':self._password,
+                'sslmode':ssl_mode,
+                'sslcert':sslcert,
+                'sslkey':sslkey,
+                'sslrootcert':sslrootcert
+            }
+            return psycopg2.extensions.make_dsn(**{k: v for k, v in kwargs.items() if v is not None})  
         else:
             return self._dsn
 

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -258,18 +258,17 @@ class DBConfiguration(object):
         # postgresql://[user[:password]@][host][:port][/dbname][?param1=value1&...]
         # return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=require'
         base_url = f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}'
-        ssl_query = ''
         if (self._ssl_mode == 'require'):
-            ssl_query = 'sslmode=require'
+            ssl_query = f'sslmode=require'
             if self._ssl_cert_path is not None:
-                ssl_query = ssl_query + '&sslcert=' + self._ssl_cert_path
+                ssl_query = f'{ssl_query}&sslcert={self._ssl_cert_path}'
             if self._ssl_key_path is not None:
-                ssl_query = ssl_query + '&sslkey=' + self._ssl_key_path
+                ssl_query = f'{ssl_query}&sslkey={self._ssl_key_path}'
             if self._ssl_root_cert_path is not None:
-                ssl_query = ssl_query + '&sslrootcert=' + self._ssl_root_cert_path
+                ssl_query = f'{ssl_query}&sslrootcert={self._ssl_root_cert_path}'
         else:
-            ssl_query = 'sslmode=disable'
-        return base_url + '?' + ssl_query
+            ssl_query = f'sslmode=disable'
+        return f'{base_url}?{ssl_query}'
 
     @property
     def dsn(self):

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -268,7 +268,7 @@ class DBConfiguration(object):
                 ssl_query = f'{ssl_query}&sslrootcert={self._ssl_root_cert_path}'
         else:
             ssl_query = f'sslmode=disable'
-        
+
         print(f'{base_url}?{ssl_query}')
         return f'{base_url}?{ssl_query}'
 

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -259,7 +259,7 @@ class DBConfiguration(object):
         # return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=require'
         base_url = f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}'
         if (self._ssl_mode in ['allow', 'prefer', 'require', 'verify-ca', 'verify-full']):
-            ssl_query = self._ssl_mode
+            ssl_query = f'sslmode={self._ssl_mode}'
             if self._ssl_cert_path is not None:
                 ssl_query = f'{ssl_query}&sslcert={self._ssl_cert_path}'
             if self._ssl_key_path is not None:

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -270,7 +270,7 @@ class DBConfiguration(object):
         else:
             ssl_query = 'sslmode=disable'
         return base_url + '?' + ssl_query
-    
+
     @property
     def dsn(self):
         if self._dsn is None:

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -213,10 +213,10 @@ class DBConfiguration(object):
         self._user = os.environ.get(prefix + "USER", user)
         self._password = os.environ.get(prefix + "PSWD", password)
         self._database_name = os.environ.get(prefix + "NAME", database_name)
-        self._ssl_mode = os.environ.get(prefix+"SSL_MODE", ssl_mode)
-        self._ssl_cert_path = os.environ.get(prefix+"SSL_CERT_PATH", ssl_cert_path)
-        self._ssl_key_path = os.environ.get(prefix+"SSL_KEY_PATH", ssl_key_path),
-        self._ssl_root_cert_path = os.environ.get(prefix+"SSL_ROOT_CERT_PATH", ssl_root_cert_path)
+        self._ssl_mode = os.environ.get(prefix + "SSL_MODE", ssl_mode)
+        self._ssl_cert_path = os.environ.get(prefix + "SSL_CERT_PATH", ssl_cert_path)
+        self._ssl_key_path = os.environ.get(prefix + "SSL_KEY_PATH", ssl_key_path),
+        self._ssl_root_cert_path = os.environ.get(prefix + "SSL_ROOT_CERT_PATH", ssl_root_cert_path)
         conn_str_required_values = [
             self._host,
             self._port,
@@ -259,13 +259,18 @@ class DBConfiguration(object):
         # return f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}?sslmode=require'
         base_url = f'postgresql://{quote(self._user)}:{quote(self._password)}@{self._host}:{self._port}/{self._database_name}'
         ssl_query = ''
-        if(self._ssl_mode == 'require'):
+        if (self._ssl_mode == 'require'):
             ssl_query = 'sslmode=require'
-            if self._ssl_cert_path is not None: ssl_query = ssl_query + '&sslcert='+self._ssl_cert_path
-            if self._ssl_key_path is not None: ssl_query = ssl_query + '&sslkey='+self._ssl_key_path
-            if self._ssl_root_cert_path is not None: ssl_query = ssl_query + '&sslrootcert='+self._ssl_root_cert_path
-        else: ssl_query = 'sslmode=disable'
+            if self._ssl_cert_path is not None:
+                ssl_query = ssl_query + '&sslcert=' + self._ssl_cert_path
+            if self._ssl_key_path is not None:
+                ssl_query = ssl_query + '&sslkey=' + self._ssl_key_path
+            if self._ssl_root_cert_path is not None:
+                ssl_query = ssl_query + '&sslrootcert=' + self._ssl_root_cert_path
+        else:
+            ssl_query = 'sslmode=disable'
         return base_url + '?' + ssl_query
+    
     @property
     def dsn(self):
         if self._dsn is None:

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -280,7 +280,11 @@ class DBConfiguration(object):
                 user=self._user,
                 host=self._host,
                 port=self._port,
-                password=self._password
+                password=self._password,
+                sslmode=self._ssl_mode,
+                sslcert=self._ssl_cert_path,
+                sslkey=self._ssl_key_path,
+                sslrootcert=self._ssl_root_cert_path
             )
         else:
             return self._dsn

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -275,17 +275,27 @@ class DBConfiguration(object):
     @property
     def dsn(self):
         if self._dsn is None:
-            return psycopg2.extensions.make_dsn(
-                dbname=self._database_name,
-                user=self._user,
-                host=self._host,
-                port=self._port,
-                password=self._password,
-                sslmode=self._ssl_mode,
-                sslcert=self._ssl_cert_path,
-                sslkey=self._ssl_key_path,
-                sslrootcert=self._ssl_root_cert_path
-            )
+            if (self._ssl_mode in ['allow', 'prefer', 'require', 'verify-ca', 'verify-full']):
+                return psycopg2.extensions.make_dsn(
+                    dbname=self._database_name,
+                    user=self._user,
+                    host=self._host,
+                    port=self._port,
+                    password=self._password,
+                    sslmode=self._ssl_mode,
+                    sslcert=self._ssl_cert_path,
+                    sslkey=self._ssl_key_path,
+                    sslrootcert=self._ssl_root_cert_path
+                )
+            else:
+                return psycopg2.extensions.make_dsn(
+                    dbname=self._database_name,
+                    user=self._user,
+                    host=self._host,
+                    port=self._port,
+                    password=self._password,
+                    sslmode='disable'
+                )
         else:
             return self._dsn
 

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -268,6 +268,8 @@ class DBConfiguration(object):
                 ssl_query = f'{ssl_query}&sslrootcert={self._ssl_root_cert_path}'
         else:
             ssl_query = f'sslmode=disable'
+        
+        print(f'{base_url}?{ssl_query}')
         return f'{base_url}?{ssl_query}'
 
     @property

--- a/services/utils/__init__.py
+++ b/services/utils/__init__.py
@@ -295,7 +295,7 @@ class DBConfiguration(object):
                 'sslkey': sslkey,
                 'sslrootcert': sslrootcert
             }
-            return psycopg2.extensions.make_dsn(**{k: v for k, v in kwargs.items() if v is not None})  
+            return psycopg2.extensions.make_dsn(**{k: v for k, v in kwargs.items() if v is not None})
         else:
             return self._dsn
 

--- a/services/utils/tests/__init__.py
+++ b/services/utils/tests/__init__.py
@@ -1,5 +1,6 @@
 from services.utils import DBConfiguration
 import pytest
+import os
 
 
 def get_test_dbconf():
@@ -7,8 +8,25 @@ def get_test_dbconf():
     Returns a DBConfiguration suitable for the test environment, or exits pytest completely upon failure
     """
     db_conf = DBConfiguration(timeout=1)
+    prefix="MF_METADATA_DB_"
+    ssl_mode = os.environ.get(prefix + "SSL_MODE")
+    ssl_cert_path = os.environ.get(prefix + "SSL_CERT_PATH")
+    ssl_key_path = os.environ.get(prefix + "SSL_KEY_PATH"),
+    ssl_root_cert_path = os.environ.get(prefix + "SSL_ROOT_CERT_PATH")
 
-    if db_conf.dsn != "dbname=test user=test host=db_test port=5432 password=test":
+    expected_dsn = f"dbname=test user=test host=db_test port=5432 password=test"
+    if (ssl_mode in ['allow', 'prefer', 'require', 'verify-ca', 'verify-full']):
+        ssl_query = f'sslmode={ssl_mode}'
+        if ssl_cert_path is not None:
+            ssl_query = f'{ssl_query} sslcert={ssl_cert_path}'
+        if ssl_key_path is not None:
+            ssl_query = f'{ssl_query} sslkey={ssl_key_path}'
+        if ssl_root_cert_path is not None:
+            ssl_query = f'{ssl_query} sslrootcert={ssl_root_cert_path}'
+    else:
+        ssl_query = f'sslmode=disable'
+    
+    if db_conf.dsn != f"{expected_dsn} {ssl_query}":
         pytest.exit("The test suite should only be run in a test environment. \n \
             Configured database host is not suited for running tests. \n \
             expected DSN to be: dbname=test user=test host=db_test port=5432 password=test")

--- a/services/utils/tests/__init__.py
+++ b/services/utils/tests/__init__.py
@@ -8,7 +8,7 @@ def get_test_dbconf():
     Returns a DBConfiguration suitable for the test environment, or exits pytest completely upon failure
     """
     db_conf = DBConfiguration(timeout=1)
-    prefix="MF_METADATA_DB_"
+    prefix = "MF_METADATA_DB_"
     ssl_mode = os.environ.get(prefix + "SSL_MODE")
     ssl_cert_path = os.environ.get(prefix + "SSL_CERT_PATH")
     ssl_key_path = os.environ.get(prefix + "SSL_KEY_PATH"),
@@ -25,7 +25,7 @@ def get_test_dbconf():
             ssl_query = f'{ssl_query} sslrootcert={ssl_root_cert_path}'
     else:
         ssl_query = f'sslmode=disable'
-    
+
     if db_conf.dsn != f"{expected_dsn} {ssl_query}":
         pytest.exit("The test suite should only be run in a test environment. \n \
             Configured database host is not suited for running tests. \n \

--- a/services/utils/tests/unit_tests/utils_test.py
+++ b/services/utils/tests/unit_tests/utils_test.py
@@ -145,11 +145,13 @@ def test_db_conf_env_custom_prefix():
 def test_db_conf_env_dsn():
     with set_env({'MF_METADATA_DB_DSN': 'foo'}):
         # Should use default dsn with invalid dsn in environment
-        assert DBConfiguration().dsn == 'dbname=postgres user=postgres host=localhost port=5432 password=postgres'
+        #assert DBConfiguration().dsn == 'dbname=postgres user=postgres host=localhost port=5432 password=postgres'
+        assert DBConfiguration().dsn == generate_dsn(host="localhost", port=5432, user="postgres", password="postgres", database_name="postgres")
 
     with set_env({'MF_METADATA_DB_DSN': 'dbname=testgres user=test_user host=test_host port=1234 password=test_pwd'}):
         # valid DSN in env should set correctly.
-        assert DBConfiguration().dsn == 'dbname=testgres user=test_user host=test_host port=1234 password=test_pwd'
+        #assert DBConfiguration().dsn == 'dbname=testgres user=test_user host=test_host port=1234 password=test_pwd'
+        assert DBConfiguration().dsn == generate_dsn(host="test_host", port=1234, user="test_user", password="test_pwd", database_name="testgres")
 
 
 def test_db_conf_pool_size():

--- a/services/utils/tests/unit_tests/utils_test.py
+++ b/services/utils/tests/unit_tests/utils_test.py
@@ -148,7 +148,7 @@ def test_db_conf_env_dsn():
         #assert DBConfiguration().dsn == 'dbname=postgres user=postgres host=localhost port=5432 password=postgres'
         assert DBConfiguration().dsn == generate_dsn(host="localhost", port=5432, user="postgres", password="postgres", database_name="postgres")
 
-    with set_env({'MF_METADATA_DB_DSN': 'dbname=testgres user=test_user host=test_host port=1234 password=test_pwd'}):
+    with set_env({'MF_METADATA_DB_DSN': 'dbname=testgres user=test_user host=test_host port=1234 password=test_pwd sslmode=disable'}):
         # valid DSN in env should set correctly.
         #assert DBConfiguration().dsn == 'dbname=testgres user=test_user host=test_host port=1234 password=test_pwd'
         assert DBConfiguration().dsn == generate_dsn(host="test_host", port=1234, user="test_user", password="test_pwd", database_name="testgres")

--- a/services/utils/tests/unit_tests/utils_test.py
+++ b/services/utils/tests/unit_tests/utils_test.py
@@ -8,6 +8,27 @@ from services.utils import format_qs, format_baseurl, DBConfiguration, handle_ex
 pytestmark = [pytest.mark.unit_tests]
 
 
+def generate_dsn(host, port, user, password, database_name):
+    prefix="MF_METADATA_DB_"
+    ssl_mode = os.environ.get(prefix + "SSL_MODE")
+    ssl_cert_path = os.environ.get(prefix + "SSL_CERT_PATH")
+    ssl_key_path = os.environ.get(prefix + "SSL_KEY_PATH"),
+    ssl_root_cert_path = os.environ.get(prefix + "SSL_ROOT_CERT_PATH")
+
+    expected_dsn = f"dbname={database_name} user={user} host={host} port={port} password={password}"
+    if (ssl_mode in ['allow', 'prefer', 'require', 'verify-ca', 'verify-full']):
+        ssl_query = f'sslmode={ssl_mode}'
+        if ssl_cert_path is not None:
+            ssl_query = f'{ssl_query} sslcert={ssl_cert_path}'
+        if ssl_key_path is not None:
+            ssl_query = f'{ssl_query} sslkey={ssl_key_path}'
+        if ssl_root_cert_path is not None:
+            ssl_query = f'{ssl_query} sslrootcert={ssl_root_cert_path}'
+    else:
+        ssl_query = f'sslmode=disable'
+    
+    return f"{expected_dsn} {ssl_query}"
+
 def test_format_qs():
     qs = format_qs({
         "foo": "bar",
@@ -49,7 +70,8 @@ def set_env(environ={}):
 def test_db_conf():
     with set_env():
         db_conf = DBConfiguration()
-        assert db_conf.dsn == 'dbname=postgres user=postgres host=localhost port=5432 password=postgres'
+        #assert db_conf.dsn == 'dbname=postgres user=postgres host=localhost port=5432 password=postgres'
+        assert db_conf.dsn == generate_dsn(host="localhost", port=5432, user="postgres", password="postgres", database_name="postgres")
         assert db_conf.pool_min == 1
         assert db_conf.pool_max == 10
         assert db_conf.timeout == 60
@@ -63,7 +85,8 @@ def test_db_conf_dsn():
 def test_db_conf_arguments():
     with set_env():
         db_conf = DBConfiguration(host='foo', port=1234, user='user', password='password', database_name='bar')
-        assert db_conf.dsn == 'dbname=bar user=user host=foo port=1234 password=password'
+        #assert db_conf.dsn == 'dbname=bar user=user host=foo port=1234 password=password'
+        assert db_conf.dsn == generate_dsn(host='foo', port=1234, user='user', password='password', database_name='bar')
         assert db_conf.host == 'foo'
         assert db_conf.port == 1234
         assert db_conf.user == 'user'
@@ -83,7 +106,8 @@ def test_db_conf_env_default_prefix():
         'MF_METADATA_DB_TIMEOUT': '5'
     }):
         db_conf = DBConfiguration()
-        assert db_conf.dsn == 'dbname=bar user=user host=foo port=1234 password=password'
+        #assert db_conf.dsn == 'dbname=bar user=user host=foo port=1234 password=password'
+        assert db_conf.dsn == generate_dsn(host='foo', port=1234, user='user', password='password', database_name='bar')
         assert db_conf.host == 'foo'
         assert db_conf.port == 1234
         assert db_conf.user == 'user'
@@ -106,7 +130,8 @@ def test_db_conf_env_custom_prefix():
         'FOO_TIMEOUT': '5'
     }):
         db_conf = DBConfiguration(prefix='FOO_')
-        assert db_conf.dsn == 'dbname=bar user=user host=foo port=1234 password=password'
+        #assert db_conf.dsn == 'dbname=bar user=user host=foo port=1234 password=password'
+        assert db_conf.dsn == generate_dsn(host='foo', port=1234, user='user', password='password', database_name='bar')
         assert db_conf.host == 'foo'
         assert db_conf.port == 1234
         assert db_conf.user == 'user'

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     -rrequirements.txt
     -rrequirements.dev.txt
 commands = pytest --cov=services
-passenv = MF_METADATA_DB_HOST,MF_METADATA_DB_PORT,MF_METADATA_DB_USER,MF_METADATA_DB_PSWD,MF_METADATA_DB_NAME,MF_UI_METADATA_PORT,MF_UI_METADATA_HOST
+passenv = MF_METADATA_DB_HOST,MF_METADATA_DB_PORT,MF_METADATA_DB_USER,MF_METADATA_DB_PSWD,MF_METADATA_DB_NAME,MF_METADATA_DB_SSL_MODE,MF_UI_METADATA_PORT,MF_UI_METADATA_HOST
 extras = tests
 
 [testenv:pylint]
@@ -17,3 +17,4 @@ commands = pytest --cov=services -m unit_tests
 
 [testenv:integration]
 commands = pytest --cov=services -m integration_tests
+


### PR DESCRIPTION
Currently metaflow-service (metadata-service) does not support ssl connection to postgresql database.

PR adds options to connect through SSL.

Options are configurable by environment variables:

MF_METADATA_DB_SSL_MODE (defaults to 'disable', must be set to 'require' if ssl is needed)
MF_METADATA_DB_SSL_CERT_PATH (defaults to None, metadata services will use systems default SSL context)
MF_METADATA_DB_SSL_KEY_PATH (defaults to None, metadata services will use systems default SSL context)
MF_METADATA_DB_SSL_ROOT_CERT_PATH (defaults to None, metadata services will use systems default SSL context)